### PR TITLE
fix: improve detail page title layout

### DIFF
--- a/frontend/src/views/Detail.vue
+++ b/frontend/src/views/Detail.vue
@@ -29,7 +29,7 @@
         </div>
 
         <p class="eyebrow">{{ paper.issue_date }}</p>
-        <h1 class="article-title serif-title">
+        <h1 class="article-title serif-title" :class="{ 'article-title-en': lang === 'en' }">
           {{ lang === 'cn' ? paper.title_zh : paper.title_original }}
         </h1>
         <p class="article-subtitle">
@@ -277,15 +277,21 @@ watch(
 
 .article-title {
   margin: 12px 0 0;
-  max-width: 16ch;
+  max-width: 100%;
   color: var(--ink-strong);
-  font-size: clamp(42px, 5vw, 68px);
+  font-size: clamp(38px, 4.4vw, 60px);
+  line-height: 1.02;
+}
+
+.article-title-en {
+  max-width: 100%;
+  font-size: clamp(40px, 4.6vw, 64px);
   line-height: 0.98;
 }
 
 .article-subtitle {
   margin: 16px 0 0;
-  max-width: 52ch;
+  max-width: max;
   color: var(--ink-muted);
   font-size: 16px;
   line-height: 1.8;

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -796,7 +796,7 @@ watch(() => route.query.date, (newDate) => {
 }
 
 .story-summary {
-  max-width: 62ch;
+  max-width: 100%;
   margin: 18px 0 0;
   color: var(--ink-body);
   font-size: 16px;


### PR DESCRIPTION
Fixes #9

## Summary
- widen the detail-page title block so the heading uses more horizontal space
- reduce the forced narrow-column feel on both Chinese and English detail titles
- keep the change scoped to `Detail.vue` only

## Validation
- `cd frontend && ./node_modules/.bin/vitest run tests/frontend/detail.spec.js`
- `cd frontend && npm run build`