### PR TITLE
Fix issue 11 navigation and page titles

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -226,6 +226,7 @@ import { Close, Menu, Message } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
 
 import { subscribeEmail } from './api/papers'
+import { applyPageTitle } from './utils/pageTitle'
 
 const router = useRouter()
 const route = useRoute()
@@ -273,6 +274,7 @@ function handleLangChange(nextLang) {
   if (typeof window !== 'undefined' && typeof window.localStorage?.setItem === 'function') {
     window.localStorage.setItem('lang', nextLang)
   }
+  applyPageTitle(route, nextLang)
 }
 
 function navigateHome() {
@@ -307,6 +309,7 @@ function handleEscape(event) {
 watch(
   () => route.fullPath,
   () => {
+    applyPageTitle(route, lang.value)
     closeMobileNav()
   },
 )
@@ -320,6 +323,7 @@ watch(mobileNavOpen, async (isOpen) => {
 })
 
 onMounted(() => {
+  applyPageTitle(route, lang.value)
   window.addEventListener('keydown', handleEscape)
 })
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,7 @@ import Unsubscribe from '../views/Unsubscribe.vue'
 import Sources from '../views/Sources.vue'
 import Topic from '../views/Topic.vue'
 import Topics from '../views/Topics.vue'
+import { applyPageTitle } from '../utils/pageTitle'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -40,6 +41,11 @@ const router = createRouter({
       component: Unsubscribe
     }
   ]
+})
+
+router.afterEach((to) => {
+  const lang = typeof window !== 'undefined' ? window.localStorage?.getItem('lang') || 'cn' : 'cn'
+  applyPageTitle(to, lang)
 })
 
 export default router

--- a/frontend/src/utils/pageTitle.js
+++ b/frontend/src/utils/pageTitle.js
@@ -1,0 +1,37 @@
+export function getPageTitle(route, lang = 'cn') {
+  const pageLabel = getPageLabel(route, lang)
+  return pageLabel || 'ArxivDaily'
+}
+
+export function applyPageTitle(route, lang = 'cn') {
+  if (typeof document === 'undefined') return
+  document.title = getPageTitle(route, lang)
+}
+
+function getPageLabel(route, lang) {
+  const isCn = lang === 'cn'
+
+  switch (route?.name) {
+    case 'home':
+      return 'arXivDaily'
+    case 'detail':
+      return isCn ? '论文详情' : 'Paper Detail'
+    case 'sources':
+      return isCn ? '原始候选池' : 'Candidate Pool'
+    case 'topics':
+      return isCn ? '论文分类' : 'Topics'
+    case 'topic':
+      return getTopicTitle(route?.params?.name, isCn)
+    case 'unsubscribe':
+      return isCn ? '退订日报' : 'Unsubscribe'
+    default:
+      return ''
+  }
+}
+
+function getTopicTitle(topicName, isCn) {
+  if (!topicName) {
+    return isCn ? '方向详情' : 'Topic Detail'
+  }
+  return isCn ? `${topicName} 分类` : `${topicName} Topic`
+}

--- a/frontend/src/views/Detail.vue
+++ b/frontend/src/views/Detail.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="detail-page">
-    <button class="secondary-button back-button" type="button" @click="$router.back()">
-      {{ lang === 'cn' ? '返回' : 'Back' }}
-    </button>
-
     <div v-if="loading" class="detail-loading">
       <el-skeleton :rows="12" animated />
     </div>
@@ -218,10 +214,6 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 22px;
-}
-
-.back-button {
-  align-self: flex-start;
 }
 
 .detail-loading {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -515,7 +515,7 @@ function goNextMonth() {
 }
 
 function goToDetail(id) {
-  router.push(`/paper/${id}`)
+  openRouteInNewTab(`/paper/${id}`)
 }
 
 function goToSources(issueDate) {
@@ -524,12 +524,21 @@ function goToSources(issueDate) {
 }
 
 function goToTopics() {
-  router.push('/topics')
+  openRouteInNewTab('/topics')
 }
 
 function goToTopic(topicKey) {
   if (!topicKey) return
-  router.push(`/topic/${encodeURIComponent(topicKey)}`)
+  openRouteInNewTab(`/topic/${encodeURIComponent(topicKey)}`)
+}
+
+function openRouteInNewTab(path) {
+  const targetUrl = router.resolve(path).href
+  if (typeof window !== 'undefined' && typeof window.open === 'function') {
+    window.open(targetUrl, '_blank', 'noopener')
+    return
+  }
+  router.push(path)
 }
 
 onMounted(() => {

--- a/frontend/src/views/Topic.vue
+++ b/frontend/src/views/Topic.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="topic-page">
     <div class="page-header">
-      <button class="secondary-button" type="button" @click="$router.push('/topics')">
-        {{ lang === 'cn' ? '返回分类' : 'Back to Categories' }}
-      </button>
       <div>
         <p class="eyebrow">{{ lang === 'cn' ? '技术方向' : 'Topic' }}</p>
         <h1 class="serif-title">
@@ -32,7 +29,7 @@
           <span class="topic-date">{{ paper.issue_date }}</span>
         </div>
         <div class="topic-row-main">
-          <h3 class="serif-title" @click="$router.push(`/paper/${paper.id}`)">
+          <h3 class="serif-title" @click="openPaperInNewTab(paper.id)">
             {{ lang === 'cn' ? paper.title_zh : paper.title_original }}
           </h3>
           <p>{{ lang === 'cn' ? paper.one_line_summary : paper.one_line_summary_en }}</p>
@@ -96,6 +93,15 @@ function handlePageChange(value) {
   router.push({ query: { ...route.query, page: value } })
 }
 
+function openPaperInNewTab(paperId) {
+  const targetUrl = router.resolve(`/paper/${paperId}`).href
+  if (typeof window !== 'undefined' && typeof window.open === 'function') {
+    window.open(targetUrl, '_blank', 'noopener')
+    return
+  }
+  router.push(`/paper/${paperId}`)
+}
+
 watch(() => route.query.page, (newValue) => {
   currentPage.value = Number(newValue) || 1
   fetchTopicPapers()
@@ -112,9 +118,7 @@ onMounted(fetchTopicPapers)
 }
 
 .page-header {
-  display: flex;
-  align-items: flex-start;
-  gap: 18px;
+  display: block;
 }
 
 .page-header h1 {
@@ -191,7 +195,7 @@ onMounted(fetchTopicPapers)
   }
 
   .page-header {
-    flex-direction: column;
+    display: block;
   }
 
   .page-header h1 {

--- a/frontend/src/views/Topics.vue
+++ b/frontend/src/views/Topics.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="topics-page">
     <div class="page-header">
-      <button class="secondary-button" type="button" @click="$router.push('/')">
-        {{ lang === 'cn' ? '返回首页' : 'Back to Home' }}
-      </button>
       <div class="header-copy">
         <p class="eyebrow">{{ lang === 'cn' ? '研究方向' : 'Research tracks' }}</p>
         <h1 class="serif-title">{{ lang === 'cn' ? '论文分类' : 'Browse the archive by direction' }}</h1>
@@ -55,6 +52,11 @@ const lang = inject('lang')
 const router = useRouter()
 
 function goToTopic(topicKey) {
+  const targetUrl = router.resolve(`/topic/${topicKey}`).href
+  if (typeof window !== 'undefined' && typeof window.open === 'function') {
+    window.open(targetUrl, '_blank', 'noopener')
+    return
+  }
   router.push(`/topic/${topicKey}`)
 }
 </script>
@@ -67,9 +69,7 @@ function goToTopic(topicKey) {
 }
 
 .page-header {
-  display: flex;
-  align-items: flex-start;
-  gap: 18px;
+  display: block;
 }
 
 .header-copy h1 {
@@ -120,7 +120,7 @@ function goToTopic(topicKey) {
 
 @media (max-width: 768px) {
   .page-header {
-    flex-direction: column;
+    display: block;
   }
 
   .topic-card {

--- a/tests/frontend/app.spec.js
+++ b/tests/frontend/app.spec.js
@@ -49,4 +49,35 @@ describe('App shell', () => {
     expect(router.currentRoute.value.fullPath).toBe('/topics')
     expect(wrapper.find('.mobile-drawer').exists()).toBe(false)
   })
+
+  it('updates document title for route and language changes', async () => {
+    const HomeStub = { template: '<div>home stub</div>' }
+    const TopicStub = { template: '<div>topics stub</div>' }
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: HomeStub },
+        { path: '/topics', name: 'topics', component: TopicStub },
+      ],
+    })
+
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [ElementPlus, router],
+      },
+    })
+
+    expect(document.title).toBe('arXivDaily')
+
+    const langButtons = wrapper.findAll('.lang-option')
+    await langButtons[1].trigger('click')
+    expect(document.title).toBe('arXivDaily')
+
+    await router.push('/topics')
+    await flushPromises()
+    expect(document.title).toBe('Topics')
+  })
 })

--- a/tests/frontend/detail.spec.js
+++ b/tests/frontend/detail.spec.js
@@ -35,6 +35,7 @@ describe('Detail view', () => {
     expect(wrapper.text()).toContain('亮点一')
     expect(wrapper.findAll('.fact-block strong')[1].text()).toBe('OpenAI')
     expect(wrapper.text()).not.toContain('候选池')
+    expect(wrapper.text()).not.toContain('返回')
   })
 
   it('summarizes multiple affiliations and keeps the full list in the tooltip', async () => {

--- a/tests/frontend/home.spec.js
+++ b/tests/frontend/home.spec.js
@@ -15,15 +15,19 @@ vi.mock('../../frontend/src/api/papers', () => ({
 import Home from '../../frontend/src/views/Home.vue'
 
 describe('Home view', () => {
+  let openSpy
+
   beforeEach(() => {
     getPapersMock.mockReset()
     getPapersCalendarMock.mockReset()
     getPapersMock.mockResolvedValue(paperListPayload)
     getPapersCalendarMock.mockResolvedValue(paperCalendarPayload)
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
   })
 
   afterEach(() => {
     vi.clearAllMocks()
+    openSpy.mockRestore()
   })
 
   it('renders grouped focus and watching papers in Chinese mode', async () => {
@@ -94,6 +98,25 @@ describe('Home view', () => {
 
     expect(wrapper.text()).toContain('进入论文分类')
     expect(wrapper.text()).toContain('每页仅展示一天内容')
+  })
+
+  it('opens detail and topic routes in a new tab instead of replacing the current page', async () => {
+    const router = await createTestRouter('/', '/', Home)
+    const wrapper = mount(Home, {
+      global: {
+        provide: { lang: ref('cn') },
+        plugins: [...testPlugins, router]
+      }
+    })
+
+    await flushPromises()
+
+    await wrapper.find('.story-actions .primary-button').trigger('click')
+    await wrapper.find('.hero-actions .primary-button').trigger('click')
+
+    expect(openSpy).toHaveBeenCalledWith('/paper/1', '_blank', 'noopener')
+    expect(openSpy).toHaveBeenCalledWith('/topics', '_blank', 'noopener')
+    expect(router.currentRoute.value.path).toBe('/')
   })
 
   it('renders gray calendar cells for dates without data', async () => {

--- a/tests/frontend/topic.spec.js
+++ b/tests/frontend/topic.spec.js
@@ -13,12 +13,19 @@ vi.mock('../../frontend/src/api/papers', () => ({
 import Topic from '../../frontend/src/views/Topic.vue'
 
 describe('Topic view', () => {
+  let openSpy
+
   beforeEach(() => {
     getPapersMock.mockReset()
     getPapersMock.mockResolvedValue({
       total: 1,
       items: [paperListPayload.items[0]]
     })
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
   })
 
   it('requests direction-filtered papers and renders topic content', async () => {
@@ -39,5 +46,22 @@ describe('Topic view', () => {
     })
     expect(wrapper.text()).toContain('中文焦点标题')
     expect(wrapper.text()).toContain('焦点中文总结')
+    expect(wrapper.text()).not.toContain('返回分类')
+  })
+
+  it('opens detail pages in a new tab', async () => {
+    const router = await createTestRouter('/topic/:name', '/topic/Agent', Topic)
+    const wrapper = mount(Topic, {
+      global: {
+        provide: { lang: ref('cn') },
+        plugins: [...testPlugins, router]
+      }
+    })
+
+    await flushPromises()
+
+    await wrapper.find('.topic-row-main h3').trigger('click')
+
+    expect(openSpy).toHaveBeenCalledWith('/paper/1', '_blank', 'noopener')
   })
 })

--- a/tests/frontend/topics.spec.js
+++ b/tests/frontend/topics.spec.js
@@ -13,11 +13,18 @@ import Topics from '../../frontend/src/views/Topics.vue'
 import Topic from '../../frontend/src/views/Topic.vue'
 
 describe('Topics view', () => {
+  let openSpy
+
   beforeEach(() => {
     getPapersMock.mockReset()
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
   })
 
-  it('renders the category catalog and can route to a topic page', async () => {
+  afterEach(() => {
+    openSpy.mockRestore()
+  })
+
+  it('renders the category catalog and opens topic pages in a new tab', async () => {
     const router = createRouter({
       history: createMemoryHistory(),
       routes: [
@@ -42,6 +49,7 @@ describe('Topics view', () => {
     await wrapper.findAll('.topic-card')[0].trigger('click')
     await flushPromises()
 
-    expect(router.currentRoute.value.fullPath).toBe('/topic/Agent')
+    expect(openSpy).toHaveBeenCalledWith('/topic/Agent', '_blank', 'noopener')
+    expect(router.currentRoute.value.fullPath).toBe('/topics')
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #11
- Open paper detail and topic/category entries in a new browser tab instead of replacing the current page.
- Remove the back buttons from detail, topics, and topic pages to avoid refresh/jump behavior.
- Add route-aware document titles and remove the shared `| ArxivDaily` suffix so browser tabs are easier to distinguish.

## Verification
- `cd frontend && ./node_modules/.bin/vitest run tests/frontend/app.spec.js tests/frontend/home.spec.js tests/frontend/topics.spec.js tests/frontend/topic.spec.js tests/frontend/detail.spec.js`
- `cd frontend && npm run build`