### PR TITLE
Fix issue 13 detail metadata overflow

### DIFF
--- a/frontend/src/views/Detail.vue
+++ b/frontend/src/views/Detail.vue
@@ -43,7 +43,7 @@
         <div class="article-facts">
           <div class="fact-block interactive-lift">
             <span>{{ lang === 'cn' ? '作者' : 'Authors' }}</span>
-            <strong>{{ formatAuthors(paper.authors) || '--' }}</strong>
+            <strong :title="getAuthorTooltip(paper.authors)">{{ formatAuthors(paper.authors) || '--' }}</strong>
           </div>
           <div class="fact-block interactive-lift">
             <span>{{ lang === 'cn' ? '作者单位' : 'Affiliations' }}</span>
@@ -147,10 +147,24 @@ async function fetchDetail(id) {
 }
 
 function formatAuthors(authors = []) {
+  const authorNames = authors
+    .map((author) => (typeof author === 'string' ? author : author.name))
+    .filter(Boolean)
+
+  if (authorNames.length <= 3) {
+    return authorNames.join(', ')
+  }
+
+  const lead = authorNames.slice(0, 3).join(', ')
+  const remaining = authorNames.length - 3
+  return lang.value === 'cn' ? `${lead} 等 ${remaining} 位作者` : `${lead} +${remaining} more`
+}
+
+function getAuthorTooltip(authors = []) {
   return authors
     .map((author) => (typeof author === 'string' ? author : author.name))
     .filter(Boolean)
-    .join(', ')
+    .join('\n')
 }
 
 function getCategoryLabel(category) {
@@ -181,13 +195,13 @@ function getAffiliationLabel(paperData) {
   if (affiliations.length === 0) {
     return lang.value === 'cn' ? '论文源未提供作者单位' : 'Affiliation not provided by the source'
   }
-  if (affiliations.length <= 2) {
+  if (affiliations.length <= 3) {
     return affiliations.join(' / ')
   }
 
-  const lead = affiliations.slice(0, 2).join(' / ')
-  const remaining = affiliations.length - 2
-  return lang.value === 'cn' ? `${lead} 等 ${affiliations.length} 家机构` : `${lead} +${remaining} more`
+  const lead = affiliations.slice(0, 3).join(' / ')
+  const remaining = affiliations.length - 3
+  return lang.value === 'cn' ? `${lead} 等 ${remaining} 家机构` : `${lead} +${remaining} more`
 }
 
 function getAffiliationTooltip(paperData) {

--- a/tests/frontend/detail.spec.js
+++ b/tests/frontend/detail.spec.js
@@ -37,6 +37,32 @@ describe('Detail view', () => {
     expect(wrapper.text()).not.toContain('候选池')
   })
 
+  it('shows only the first three authors and keeps the full list in the tooltip', async () => {
+    getPaperDetailMock.mockResolvedValue({
+      ...focusDetail,
+      authors: [
+        { name: 'Alice', affiliation: 'OpenAI' },
+        { name: 'Bob', affiliation: 'Stanford University' },
+        { name: 'Carol', affiliation: 'Google DeepMind' },
+        { name: 'Dave', affiliation: 'Anthropic' },
+      ],
+    })
+    const router = await createTestRouter('/paper/:id', '/paper/1', Detail)
+
+    const wrapper = mount(Detail, {
+      global: {
+        provide: { lang: ref('cn') },
+        plugins: [...testPlugins, router]
+      }
+    })
+
+    await flushPromises()
+
+    const authorBlock = wrapper.findAll('.fact-block strong')[0]
+    expect(authorBlock.text()).toBe('Alice, Bob, Carol 等 1 位作者')
+    expect(authorBlock.attributes('title')).toBe('Alice\nBob\nCarol\nDave')
+  })
+
   it('summarizes multiple affiliations and keeps the full list in the tooltip', async () => {
     getPaperDetailMock.mockResolvedValue({
       ...focusDetail,
@@ -44,8 +70,9 @@ describe('Detail view', () => {
       authors: [
         { name: 'Alice', affiliation: 'OpenAI' },
         { name: 'Bob', affiliation: 'Stanford University' },
-        { name: 'Carol', affiliation: 'OpenAI' },
+        { name: 'Carol', affiliation: 'Google DeepMind' },
         { name: 'Dave', affiliation: 'Google DeepMind' },
+        { name: 'Eve', affiliation: 'Anthropic' },
       ],
     })
     const router = await createTestRouter('/paper/:id', '/paper/1', Detail)
@@ -60,8 +87,8 @@ describe('Detail view', () => {
     await flushPromises()
 
     const affiliationBlock = wrapper.findAll('.fact-block strong')[1]
-    expect(affiliationBlock.text()).toBe('OpenAI / Stanford University 等 3 家机构')
-    expect(affiliationBlock.attributes('title')).toBe('OpenAI\nStanford University\nGoogle DeepMind')
+    expect(affiliationBlock.text()).toBe('OpenAI / Stanford University / Google DeepMind 等 1 家机构')
+    expect(affiliationBlock.attributes('title')).toBe('OpenAI\nStanford University\nGoogle DeepMind\nAnthropic')
   })
 
   it('shows an explicit fallback when the source does not provide affiliations', async () => {


### PR DESCRIPTION
## Summary
- Fixes #13
- Limit detail-page author display to the first three names when the list is long.
- Limit affiliation display to the first three unique institutions when the list is long.
- Keep the full author and affiliation list in the tooltip so the raw metadata is still inspectable.

## Verification
- 
 RUN  v4.1.4 /Users/zhangshijie/Desktop/Project/AI_paper_summary_website/frontend


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  23:53:10
   Duration  1.37s (transform 102ms, setup 23ms, import 652ms, tests 47ms, environment 551ms)
- Confirmed the detail view still renders fallback text correctly when affiliation data is missing.