### PR TITLE
Fix issue 7 add dark mode

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -29,6 +29,15 @@
         </nav>
 
         <div class="shell-actions desktop-only">
+          <button
+            class="theme-toggle secondary-button interactive-press"
+            type="button"
+            :aria-label="themeToggleLabel"
+            @click="toggleTheme"
+          >
+            <el-icon :size="16"><component :is="themeIcon" /></el-icon>
+            <span>{{ themeToggleShortLabel }}</span>
+          </button>
           <div class="lang-pill" role="tablist" :aria-label="lang === 'cn' ? '语言切换' : 'Language switch'">
             <button
               type="button"
@@ -120,6 +129,14 @@
           >
             <span>{{ lang === 'cn' ? '分类页' : 'Topics' }}</span>
             <small>{{ lang === 'cn' ? '按方向查看历史精选' : 'Browse the archive by research track' }}</small>
+          </button>
+        </div>
+
+        <div class="drawer-block">
+          <p class="eyebrow">{{ lang === 'cn' ? '主题' : 'Theme' }}</p>
+          <button class="theme-toggle secondary-button interactive-press" type="button" @click="toggleTheme">
+            <el-icon :size="16"><component :is="themeIcon" /></el-icon>
+            <span>{{ themeToggleLabel }}</span>
           </button>
         </div>
 
@@ -222,7 +239,7 @@
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Close, Menu, Message } from '@element-plus/icons-vue'
+import { Close, Menu, Message, Moon, Sunny } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
 
 import { subscribeEmail } from './api/papers'
@@ -242,7 +259,25 @@ function readStoredLang() {
   return 'cn'
 }
 
+function readStoredTheme() {
+  try {
+    if (typeof window !== 'undefined' && typeof window.localStorage?.getItem === 'function') {
+      const stored = window.localStorage.getItem('theme')
+      if (stored === 'dark' || stored === 'light') {
+        return stored
+      }
+    }
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+  } catch (error) {
+    return 'light'
+  }
+  return 'light'
+}
+
 const lang = ref(readStoredLang())
+const theme = ref(readStoredTheme())
 provide('lang', lang)
 
 const subscribeDialogVisible = ref(false)
@@ -256,6 +291,17 @@ const subscribeForm = reactive({
 })
 
 const isTopicRoute = computed(() => route.path.startsWith('/topics') || route.path.startsWith('/topic/'))
+const themeIcon = computed(() => (theme.value === 'dark' ? Sunny : Moon))
+const themeToggleLabel = computed(() =>
+  theme.value === 'dark'
+    ? (lang.value === 'cn' ? '切换到浅色模式' : 'Switch to light mode')
+    : (lang.value === 'cn' ? '切换到黑夜模式' : 'Switch to dark mode')
+)
+const themeToggleShortLabel = computed(() =>
+  theme.value === 'dark'
+    ? (lang.value === 'cn' ? '浅色' : 'Light')
+    : (lang.value === 'cn' ? '黑夜' : 'Dark')
+)
 
 const emailMessages = computed(() => ({
   required: lang.value === 'cn' ? '请输入邮箱地址' : 'Please enter an email',
@@ -275,6 +321,21 @@ function handleLangChange(nextLang) {
     window.localStorage.setItem('lang', nextLang)
   }
   applyPageTitle(route, nextLang)
+}
+
+function applyTheme(nextTheme) {
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset.theme = nextTheme
+    document.documentElement.style.colorScheme = nextTheme
+  }
+}
+
+function toggleTheme() {
+  theme.value = theme.value === 'dark' ? 'light' : 'dark'
+  if (typeof window !== 'undefined' && typeof window.localStorage?.setItem === 'function') {
+    window.localStorage.setItem('theme', theme.value)
+  }
+  applyTheme(theme.value)
 }
 
 function navigateHome() {
@@ -323,6 +384,7 @@ watch(mobileNavOpen, async (isOpen) => {
 })
 
 onMounted(() => {
+  applyTheme(theme.value)
   applyPageTitle(route, lang.value)
   window.addEventListener('keydown', handleEscape)
 })
@@ -438,7 +500,7 @@ async function handleSubscribe() {
 .nav-link.active,
 .nav-link:hover {
   color: var(--ink-strong);
-  background: rgba(196, 111, 60, 0.1);
+  background: var(--accent-soft);
 }
 
 .shell-actions {
@@ -447,12 +509,19 @@ async function handleSubscribe() {
   gap: 12px;
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 .lang-pill {
   display: inline-flex;
   padding: 4px;
   border-radius: 999px;
   border: 1px solid var(--line-soft);
-  background: rgba(255, 250, 242, 0.84);
+  background: var(--panel-solid);
 }
 
 .lang-option {
@@ -464,8 +533,8 @@ async function handleSubscribe() {
 }
 
 .lang-option.active {
-  background: var(--ink-strong);
-  color: #fffaf2;
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text);
 }
 
 .subscribe-button {
@@ -548,7 +617,7 @@ async function handleSubscribe() {
   justify-content: center;
   border-radius: 50%;
   color: var(--ink-strong);
-  background: rgba(255, 250, 242, 0.7);
+  background: var(--panel-solid);
   border: 1px solid var(--line-soft);
   cursor: pointer;
   flex-shrink: 0;
@@ -574,7 +643,7 @@ async function handleSubscribe() {
   inset: 0;
   z-index: 39;
   border: 0;
-  background: rgba(34, 29, 23, 0.22);
+  background: var(--overlay-bg);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   cursor: pointer;
@@ -616,7 +685,7 @@ async function handleSubscribe() {
   padding: 16px;
   border-radius: 20px;
   border: 1px solid var(--line-soft);
-  background: rgba(255, 250, 242, 0.7);
+  background: var(--panel-solid);
 }
 
 .drawer-link {
@@ -640,8 +709,8 @@ async function handleSubscribe() {
 }
 
 .drawer-link.active {
-  border-color: rgba(196, 111, 60, 0.24);
-  background: rgba(196, 111, 60, 0.1);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
 }
 
 .drawer-block {
@@ -649,6 +718,10 @@ async function handleSubscribe() {
 }
 
 .drawer-block .lang-pill {
+  margin-top: 14px;
+}
+
+.drawer-block .theme-toggle {
   margin-top: 14px;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,17 +1,29 @@
 :root {
   --page-bg: #f4eee3;
   --page-bg-soft: #efe7d9;
+  --page-bg-radial: rgba(196, 111, 60, 0.12);
+  --page-bg-start: #f7f1e7;
+  --page-bg-end: #efe6d7;
   --panel-bg: rgba(255, 251, 244, 0.68);
   --panel-strong: rgba(255, 251, 244, 0.82);
   --panel-contrast: rgba(240, 228, 210, 0.74);
+  --panel-soft: rgba(255, 250, 242, 0.72);
+  --panel-solid: rgba(255, 250, 242, 0.84);
+  --panel-hover: rgba(255, 250, 242, 0.56);
+  --panel-faint: rgba(255, 250, 242, 0.48);
+  --panel-input: rgba(247, 240, 228, 0.92);
   --ink-strong: #221d17;
   --ink-body: #433a31;
   --ink-muted: #77695c;
+  --ink-inverse: #fffaf2;
   --line-soft: rgba(83, 69, 54, 0.14);
   --line-strong: rgba(83, 69, 54, 0.24);
   --accent: #c46f3c;
   --accent-deep: #9b5429;
   --accent-soft: rgba(196, 111, 60, 0.12);
+  --accent-soft-strong: rgba(196, 111, 60, 0.18);
+  --accent-line: rgba(196, 111, 60, 0.28);
+  --accent-line-strong: rgba(196, 111, 60, 0.34);
   --focus-tone: #a94e27;
   --watch-tone: #6d6658;
   --candidate-tone: #8c7662;
@@ -23,6 +35,26 @@
   --glass-blur: 22px;
   --glass-blur-strong: 30px;
   --glass-sheen: linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.06));
+  --overlay-bg: rgba(34, 29, 23, 0.22);
+  --selection-bg: rgba(196, 111, 60, 0.18);
+  --chip-bg: rgba(255, 250, 242, 0.74);
+  --chip-focus-bg: rgba(169, 78, 39, 0.08);
+  --chip-watch-bg: rgba(109, 102, 88, 0.08);
+  --chip-candidate-bg: rgba(140, 118, 98, 0.1);
+  --button-primary-bg: #221d17;
+  --button-primary-border: rgba(34, 29, 23, 0.92);
+  --button-primary-text: #fffaf2;
+  --button-secondary-bg: rgba(255, 250, 242, 0.82);
+  --button-secondary-border: rgba(83, 69, 54, 0.14);
+  --button-secondary-text: #221d17;
+  --button-tertiary-bg: rgba(255, 250, 242, 0.45);
+  --button-tertiary-border: rgba(83, 69, 54, 0.1);
+  --button-tertiary-text: #433a31;
+  --dialog-bg: rgba(255, 250, 242, 0.9);
+  --calendar-muted-bg: rgba(103, 92, 79, 0.08);
+  --calendar-muted-text: rgba(67, 58, 49, 0.44);
+  --poster-gradient: linear-gradient(180deg, rgba(255, 251, 244, 0.8), rgba(240, 228, 210, 0.9));
+  --poster-glow: radial-gradient(circle at top right, rgba(196, 111, 60, 0.18), transparent 42%);
   --radius-xl: 32px;
   --radius-lg: 24px;
   --radius-md: 18px;
@@ -38,6 +70,63 @@
   --tap-scale: 0.992;
 }
 
+:root[data-theme='dark'] {
+  --page-bg: #111417;
+  --page-bg-soft: #171c20;
+  --page-bg-radial: rgba(196, 111, 60, 0.08);
+  --page-bg-start: #1a1e23;
+  --page-bg-end: #12161a;
+  --panel-bg: rgba(24, 29, 34, 0.7);
+  --panel-strong: rgba(28, 34, 39, 0.82);
+  --panel-contrast: rgba(34, 40, 46, 0.8);
+  --panel-soft: rgba(31, 37, 43, 0.76);
+  --panel-solid: rgba(30, 36, 41, 0.88);
+  --panel-hover: rgba(38, 44, 50, 0.84);
+  --panel-faint: rgba(27, 33, 39, 0.72);
+  --panel-input: rgba(24, 29, 34, 0.96);
+  --ink-strong: #f5efe6;
+  --ink-body: #ddd2c5;
+  --ink-muted: #a99b8d;
+  --ink-inverse: #16120d;
+  --line-soft: rgba(235, 223, 209, 0.12);
+  --line-strong: rgba(235, 223, 209, 0.2);
+  --accent: #d88a58;
+  --accent-deep: #ebb084;
+  --accent-soft: rgba(216, 138, 88, 0.16);
+  --accent-soft-strong: rgba(216, 138, 88, 0.24);
+  --accent-line: rgba(216, 138, 88, 0.34);
+  --accent-line-strong: rgba(216, 138, 88, 0.44);
+  --focus-tone: #f0a47a;
+  --watch-tone: #c4b6a5;
+  --candidate-tone: #bba893;
+  --success-tone: #83a391;
+  --danger-tone: #d29185;
+  --shadow-soft: 0 24px 80px rgba(0, 0, 0, 0.28);
+  --shadow-card: 0 16px 40px rgba(0, 0, 0, 0.24);
+  --shadow-hover: 0 22px 48px rgba(0, 0, 0, 0.34);
+  --glass-sheen: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.01));
+  --overlay-bg: rgba(5, 7, 9, 0.52);
+  --selection-bg: rgba(216, 138, 88, 0.28);
+  --chip-bg: rgba(28, 34, 39, 0.9);
+  --chip-focus-bg: rgba(240, 164, 122, 0.12);
+  --chip-watch-bg: rgba(196, 182, 165, 0.12);
+  --chip-candidate-bg: rgba(187, 168, 147, 0.12);
+  --button-primary-bg: #f1e6d9;
+  --button-primary-border: rgba(241, 230, 217, 0.9);
+  --button-primary-text: #1a1611;
+  --button-secondary-bg: rgba(30, 36, 41, 0.9);
+  --button-secondary-border: rgba(235, 223, 209, 0.12);
+  --button-secondary-text: #f5efe6;
+  --button-tertiary-bg: rgba(30, 36, 41, 0.72);
+  --button-tertiary-border: rgba(235, 223, 209, 0.1);
+  --button-tertiary-text: #ddd2c5;
+  --dialog-bg: rgba(22, 27, 31, 0.96);
+  --calendar-muted-bg: rgba(235, 223, 209, 0.06);
+  --calendar-muted-text: rgba(221, 210, 197, 0.46);
+  --poster-gradient: linear-gradient(180deg, rgba(31, 37, 43, 0.95), rgba(24, 29, 34, 0.96));
+  --poster-glow: radial-gradient(circle at top right, rgba(216, 138, 88, 0.16), transparent 42%);
+}
+
 *,
 *::before,
 *::after {
@@ -46,8 +135,8 @@
 
 html {
   background:
-    radial-gradient(circle at top left, rgba(196, 111, 60, 0.12), transparent 30%),
-    linear-gradient(180deg, #f7f1e7 0%, #efe6d7 100%);
+    radial-gradient(circle at top left, var(--page-bg-radial), transparent 30%),
+    linear-gradient(180deg, var(--page-bg-start) 0%, var(--page-bg-end) 100%);
 }
 
 body {
@@ -61,7 +150,7 @@ body {
 }
 
 body::selection {
-  background: rgba(196, 111, 60, 0.18);
+  background: var(--selection-bg);
 }
 
 button,
@@ -144,7 +233,7 @@ a {
   gap: 8px;
   padding: 8px 12px;
   border-radius: 999px;
-  background: rgba(255, 250, 242, 0.74);
+  background: var(--chip-bg);
   border: 1px solid var(--line-soft);
   color: var(--ink-body);
   font-size: 12px;
@@ -158,19 +247,19 @@ a {
 .focus-chip {
   color: var(--focus-tone);
   border-color: rgba(169, 78, 39, 0.2);
-  background: rgba(169, 78, 39, 0.08);
+  background: var(--chip-focus-bg);
 }
 
 .watching-chip {
   color: var(--watch-tone);
   border-color: rgba(109, 102, 88, 0.22);
-  background: rgba(109, 102, 88, 0.08);
+  background: var(--chip-watch-bg);
 }
 
 .candidate-chip {
   color: var(--candidate-tone);
   border-color: rgba(140, 118, 98, 0.24);
-  background: rgba(140, 118, 98, 0.1);
+  background: var(--chip-candidate-bg);
 }
 
 .app-link {
@@ -225,9 +314,9 @@ a {
 }
 
 .primary-button {
-  border: 1px solid rgba(34, 29, 23, 0.92);
-  background: #221d17;
-  color: #fffaf2;
+  border: 1px solid var(--button-primary-border);
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
     inset 0 -1px 0 rgba(0, 0, 0, 0.18),
@@ -235,15 +324,15 @@ a {
 }
 
 .secondary-button {
-  background: rgba(255, 250, 242, 0.82);
-  color: var(--ink-strong);
-  border: 1px solid var(--line-soft);
+  background: var(--button-secondary-bg);
+  color: var(--button-secondary-text);
+  border: 1px solid var(--button-secondary-border);
 }
 
 .tertiary-button {
-  background: rgba(255, 250, 242, 0.45);
-  color: var(--ink-body);
-  border: 1px solid rgba(83, 69, 54, 0.1);
+  background: var(--button-tertiary-bg);
+  color: var(--button-tertiary-text);
+  border: 1px solid var(--button-tertiary-border);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -265,7 +354,7 @@ a {
   overflow: hidden;
   background:
     var(--glass-sheen),
-    rgba(255, 250, 242, 0.9);
+    var(--dialog-bg);
   box-shadow: 0 28px 80px rgba(34, 29, 23, 0.18);
   backdrop-filter: blur(var(--glass-blur-strong));
   -webkit-backdrop-filter: blur(var(--glass-blur-strong));
@@ -292,7 +381,7 @@ a {
 .el-input__wrapper {
   border-radius: 14px;
   box-shadow: none !important;
-  background: rgba(247, 240, 228, 0.92);
+  background: var(--panel-input);
 }
 
 .el-empty {

--- a/frontend/src/views/Detail.vue
+++ b/frontend/src/views/Detail.vue
@@ -297,7 +297,7 @@ watch(
 .fact-block {
   padding: 16px;
   border-radius: 18px;
-  background: rgba(255, 250, 242, 0.72);
+  background: var(--panel-soft);
   border: 1px solid var(--line-soft);
 }
 

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -626,8 +626,8 @@ watch(() => route.query.date, (newDate) => {
   padding: 24px;
   border-radius: calc(var(--radius-xl) - 4px);
   background:
-    linear-gradient(180deg, rgba(255, 251, 244, 0.8), rgba(240, 228, 210, 0.9)),
-    radial-gradient(circle at top right, rgba(196, 111, 60, 0.18), transparent 42%);
+    var(--poster-gradient),
+    var(--poster-glow);
   border: 1px solid rgba(83, 69, 54, 0.1);
   transition: transform var(--motion-smooth) var(--ease-smooth), box-shadow var(--motion-smooth) var(--ease-smooth);
 }
@@ -647,7 +647,7 @@ watch(() => route.query.date, (newDate) => {
 .poster-metric {
   padding: 14px;
   border-radius: 18px;
-  background: rgba(255, 250, 242, 0.82);
+  background: var(--panel-strong);
   border: 1px solid rgba(83, 69, 54, 0.1);
 }
 
@@ -771,8 +771,8 @@ watch(() => route.query.date, (newDate) => {
 
 .direction-chip:hover {
   color: var(--accent-deep);
-  border-color: rgba(196, 111, 60, 0.28);
-  background: rgba(196, 111, 60, 0.12);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
 }
 
 .story-score {
@@ -860,7 +860,7 @@ watch(() => route.query.date, (newDate) => {
 }
 
 .watching-row:hover {
-  background: rgba(255, 250, 242, 0.56);
+  background: var(--panel-hover);
 }
 
 .watching-meta {
@@ -947,7 +947,7 @@ watch(() => route.query.date, (newDate) => {
   height: 36px;
   border-radius: 50%;
   border: 1px solid var(--line-soft);
-  background: rgba(255, 250, 242, 0.7);
+  background: var(--panel-solid);
   color: var(--ink-body);
   cursor: pointer;
 }
@@ -979,7 +979,7 @@ watch(() => route.query.date, (newDate) => {
   height: 38px;
   border-radius: 12px;
   border: 1px solid transparent;
-  background: rgba(255, 250, 242, 0.92);
+  background: var(--panel-strong);
   color: var(--ink-body);
   cursor: pointer;
   transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
@@ -991,18 +991,18 @@ watch(() => route.query.date, (newDate) => {
 }
 
 .calendar-cell.has-data {
-  background: rgba(196, 111, 60, 0.12);
+  background: var(--accent-soft);
 }
 
 .calendar-cell.no-data {
-  background: rgba(103, 92, 79, 0.08);
-  color: rgba(67, 58, 49, 0.44);
+  background: var(--calendar-muted-bg);
+  color: var(--calendar-muted-text);
 }
 
 .calendar-cell.selected {
-  background: var(--ink-strong);
-  color: #fffaf2;
-  border-color: var(--ink-strong);
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text);
+  border-color: var(--button-primary-bg);
 }
 
 .calendar-cell.disabled {
@@ -1053,14 +1053,14 @@ watch(() => route.query.date, (newDate) => {
   padding: 12px 14px;
   border-radius: 16px;
   border: 1px solid var(--line-soft);
-  background: rgba(255, 250, 242, 0.68);
+  background: var(--panel-bg);
   color: var(--ink-body);
   cursor: pointer;
 }
 
 .recent-issue.active {
-  border-color: rgba(196, 111, 60, 0.34);
-  background: rgba(196, 111, 60, 0.1);
+  border-color: var(--accent-line-strong);
+  background: var(--accent-soft);
 }
 
 .recent-issue strong {
@@ -1151,7 +1151,7 @@ watch(() => route.query.date, (newDate) => {
     padding: 16px 18px;
     border-radius: 18px;
     border: 1px solid var(--line-soft);
-    background: rgba(255, 250, 242, 0.72);
+    background: var(--panel-soft);
     color: var(--ink-strong);
     cursor: pointer;
     list-style: none;

--- a/frontend/src/views/Sources.vue
+++ b/frontend/src/views/Sources.vue
@@ -264,7 +264,7 @@ onMounted(fetchCandidates)
 .sources-stat {
   padding: 16px;
   border-radius: 18px;
-  background: rgba(255, 250, 242, 0.74);
+  background: var(--panel-soft);
   border: 1px solid var(--line-soft);
 }
 
@@ -441,7 +441,7 @@ onMounted(fetchCandidates)
     grid-template-columns: 1fr;
     gap: 14px;
     padding: 20px;
-    background: rgba(255, 250, 242, 0.48);
+    background: var(--panel-faint);
     border-radius: 22px;
     margin: 12px;
     border: 1px solid var(--line-soft);

--- a/tests/frontend/app.spec.js
+++ b/tests/frontend/app.spec.js
@@ -14,8 +14,23 @@ import App from '../../frontend/src/App.vue'
 
 describe('App shell', () => {
   beforeEach(() => {
+    const storage = {}
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key) => (key in storage ? storage[key] : null),
+        setItem: (key, value) => {
+          storage[key] = String(value)
+        },
+        removeItem: (key) => {
+          delete storage[key]
+        },
+      },
+    })
     subscribeEmailMock.mockReset()
-    window.localStorage?.setItem?.('lang', 'cn')
+    window.localStorage.setItem('lang', 'cn')
+    window.localStorage.removeItem('theme')
+    delete document.documentElement.dataset.theme
   })
 
   it('opens the mobile drawer and routes to topics', async () => {
@@ -79,5 +94,34 @@ describe('App shell', () => {
     await router.push('/topics')
     await flushPromises()
     expect(document.title).toBe('Topics')
+  })
+
+  it('toggles dark mode and persists the theme choice', async () => {
+    const HomeStub = { template: '<div>home stub</div>' }
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: HomeStub },
+      ],
+    })
+
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [ElementPlus, router],
+      },
+    })
+
+    expect(document.documentElement.dataset.theme).toBe('light')
+
+    await wrapper.find('.theme-toggle').trigger('click')
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(window.localStorage.getItem('theme')).toBe('dark')
+
+    await wrapper.find('.theme-toggle').trigger('click')
+    expect(document.documentElement.dataset.theme).toBe('light')
+    expect(window.localStorage.getItem('theme')).toBe('light')
   })
 })


### PR DESCRIPTION
## Summary
- Fixes #7
- Add a persistent light/dark theme switcher in the app shell.
- Apply theme state through root-level design tokens instead of page-specific ad hoc classes.
- Update the navigation shell, homepage, detail page, and candidate pool surfaces so dark mode has consistent contrast and glass styling.
- Add an app-shell test that verifies theme toggling and persistence.

## Verification
- 
> frontend@0.0.0 test:run
> vitest run


 RUN  v4.1.4 /Users/zhangshijie/Desktop/Project/AI_paper_summary_website/frontend


 Test Files  6 passed (6)
      Tests  18 passed (18)
   Start at  00:01:09
   Duration  2.95s (transform 2.05s, setup 432ms, import 8.77s, tests 977ms, environment 5.97s)
- 
> frontend@0.0.0 build
> vite build

vite v8.0.1 building client environment for production...
[2Ktransforming...✓ 1647 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.46 kB │ gzip:   0.29 kB
dist/assets/index-uUTRY9XC.css    387.13 kB │ gzip:  53.84 kB
dist/assets/index-B_hU-7mb.js   1,050.69 kB │ gzip: 341.77 kB

✓ built in 459ms