### PR TITLE
Fix issue 18 remove candidate pool cap

### DIFF
--- a/backend/app/core/specs.py
+++ b/backend/app/core/specs.py
@@ -5,7 +5,6 @@ WATCHING_THRESHOLD = 50
 
 FOCUS_CAPACITY = 5
 WATCHING_CAPACITY = 12
-DAILY_SNAPSHOT_CAPACITY = 50
 
 SUMMARY_CATEGORIES = ("focus", "watching", "candidate")
 CANDIDATE_REASONS = ("low_score", "capacity_overflow", "reviewer_rejected")

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -12,7 +12,6 @@ from app.services.notification_service import send_owner_alert, shanghai_today
 from app.services.scorer import Scorer
 from app.core.config import settings
 from app.core.specs import (
-    DAILY_SNAPSHOT_CAPACITY,
     FOCUS_CAPACITY,
     FOCUS_THRESHOLD,
     WATCHING_CAPACITY,
@@ -68,15 +67,6 @@ class Pipeline:
             )
             if not scored_papers:
                 raise ValueError(f"No papers fetched for {issue_date.isoformat()}.")
-
-            if len(scored_papers) > DAILY_SNAPSHOT_CAPACITY:
-                _safe_progress_log(
-                    (
-                        f"[pipeline] truncating scored snapshot: "
-                        f"total={len(scored_papers)} keep_top={DAILY_SNAPSHOT_CAPACITY}"
-                    )
-                )
-                scored_papers = scored_papers[:DAILY_SNAPSHOT_CAPACITY]
 
             (
                 focus_pool,

--- a/frontend/src/views/Sources.vue
+++ b/frontend/src/views/Sources.vue
@@ -13,8 +13,8 @@
           <p class="sources-copy">
             {{
               lang === 'cn'
-                ? '展示当日前 50 篇进入评分引擎的论文、加分项、分层结果与未入选原因。'
-                : 'A complete audit surface of scored papers, signals, tier assignment, and non-selection reasons.'
+                ? '展示当天全部进入评分引擎的论文、加分项、分层结果与未入选原因，每页 50 条。'
+                : 'A paginated audit surface of all scored papers, signals, tier assignment, and non-selection reasons, 50 per page.'
             }}
           </p>
         </div>

--- a/tests/backend/unit/test_pipeline_rules.py
+++ b/tests/backend/unit/test_pipeline_rules.py
@@ -1196,7 +1196,7 @@ def test_quantity_first_pipeline_uses_full_snapshots_and_standard_ai_batches(db_
     assert sum(1 for summary in summaries if summary.category == "watching") == 6
 
 
-def test_run_truncates_daily_snapshot_to_top_50(db_session):
+def test_run_persists_full_daily_snapshot_for_candidate_pool(db_session):
     pipeline = Pipeline(db_session)
     raw_ids = [f"paper-{index:02d}" for index in range(60)]
     score_map = {paper_id: 200 - index for index, paper_id in enumerate(raw_ids)}
@@ -1252,13 +1252,14 @@ def test_run_truncates_daily_snapshot_to_top_50(db_session):
     )
 
     snapshot_ids = {arxiv_id for _, arxiv_id in summaries}
-    expected_ids = set(raw_ids[:50])
+    expected_ids = set(raw_ids)
 
     assert task_log.status == "SUCCESS"
     assert task_log.fetched_count == 60
     assert task_log.processed_count == 5
-    assert len(summaries) == 50
+    assert len(summaries) == 60
     assert snapshot_ids == expected_ids
-    assert "paper-50" not in snapshot_ids
+    assert "paper-50" in snapshot_ids
+    assert "paper-59" in snapshot_ids
     assert sum(1 for summary, _ in summaries if summary.category == "focus") == 5
-    assert sum(1 for summary, _ in summaries if summary.category == "candidate") == 45
+    assert sum(1 for summary, _ in summaries if summary.category == "candidate") == 55


### PR DESCRIPTION
## Summary
- Fixes #18
- Remove the pipeline-level daily snapshot cap of 50 papers so the candidate pool can retain all scored papers for an issue date.
- Keep the candidate pool UI paginated at 50 items per page.
- Update the candidate pool copy to describe all scored papers with 50-per-page pagination.
- Update the pipeline unit test to verify the full scored snapshot is persisted.

## Verification
- cd backend && ./venv/bin/pytest ../tests/backend/unit/test_pipeline_rules.py ../tests/backend/integration/test_papers_api.py: passed, 26 tests.
- cd frontend && npm run test:run: passed, 18 tests.
- cd frontend && npm run build: passed with the existing Vite chunk size warning.

## Manual run note
- I attempted a local full pipeline run for issue_date=2026-04-24 using the new code.
- The run passed prompt/schema/runtime checks, completed Focus 5/5, and reached Watching 11/12.
- It then stalled on the final Watching external LLM call for roughly an hour, so I stopped the local run and cleared the local 2026-04-24 partial state.
- Therefore the cap-removal logic is covered by automated tests, but today full real LLM pipeline run did not complete end-to-end.