### PR TITLE
Add pipeline stage progress logs

### DIFF
--- a/backend/app/services/ai_processor.py
+++ b/backend/app/services/ai_processor.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from openai import APIConnectionError, APIError, APITimeoutError, AuthenticationError, OpenAI, PermissionDeniedError, RateLimitError
 
@@ -230,7 +230,12 @@ class AIProcessor:
     def localize_title(self, paper: Dict[str, Any]) -> str:
         return self.localize_titles([paper])[paper["arxiv_id"]]
 
-    def localize_titles(self, papers: Sequence[Dict[str, Any]], batch_size: Optional[int] = None) -> Dict[str, str]:
+    def localize_titles(
+        self,
+        papers: Sequence[Dict[str, Any]],
+        batch_size: Optional[int] = None,
+        progress_callback: Optional[Callable[[int, int, int], None]] = None,
+    ) -> Dict[str, str]:
         localized_titles: Dict[str, str] = {}
         pending: List[Dict[str, Any]] = []
         for paper in papers:
@@ -254,8 +259,11 @@ class AIProcessor:
 
         effective_batch_size = max(1, int(batch_size or settings.KIMI_TITLE_BATCH_SIZE or 1))
         max_localize_attempts = max(1, int(settings.KIMI_TITLE_LOCALIZATION_ATTEMPTS or 1))
+        total_batches = max(1, (len(pending) + effective_batch_size - 1) // effective_batch_size)
         for start in range(0, len(pending), effective_batch_size):
             batch = list(pending[start:start + effective_batch_size])
+            if progress_callback is not None:
+                progress_callback((start // effective_batch_size) + 1, total_batches, len(batch))
             prompt_lines = [
                 "请把以下英文论文标题翻译成简洁、自然、面向中文技术读者的中文标题。",
                 "保留模型名、数据集名、框架名、缩写和关键专有名词，不要添加编号或解释。",

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -358,6 +358,29 @@ class Pipeline:
         candidate_limit = max(target_count, target_count * multiplier)
         return min(queued_count, configured_cap, candidate_limit)
 
+    @staticmethod
+    def _summarize_progress_detail(detail: Any) -> str:
+        compact = " ".join(str(detail).split())
+        if len(compact) <= 160:
+            return compact
+        return compact[:157] + "..."
+
+    def _log_stage_progress(
+        self,
+        papers: Sequence[Dict[str, Any]],
+        category: str,
+        stage: str,
+        status: str,
+        *,
+        attempt_no: int,
+        detail: Any | None = None,
+    ) -> None:
+        paper_ids = ",".join(str(paper.get("arxiv_id") or "-") for paper in papers) or "-"
+        message = f"[pipeline][{category}][{paper_ids}][{stage}] {status} attempt={attempt_no}"
+        if detail is not None:
+            message += f" detail={self._summarize_progress_detail(detail)}"
+        _safe_progress_log(message)
+
     def _refresh_selected_titles(self, issue_date: date) -> int:
         targeted_summaries = (
             self.db.query(PaperSummary)
@@ -379,7 +402,21 @@ class Pipeline:
             }
             for summary in targeted_summaries
         ]
-        localized_titles = self.ai_processor.localize_titles(title_payload, batch_size=settings.KIMI_TITLE_BATCH_SIZE)
+        total_titles = len(title_payload)
+
+        def log_title_refresh_batch(batch_index: int, total_batches: int, batch_size: int) -> None:
+            _safe_progress_log(
+                (
+                    f"[pipeline][title-refresh] issue_date={issue_date.isoformat()} "
+                    f"batch={batch_index}/{total_batches} size={batch_size} total={total_titles}"
+                )
+            )
+
+        localized_titles = self.ai_processor.localize_titles(
+            title_payload,
+            batch_size=settings.KIMI_TITLE_BATCH_SIZE,
+            progress_callback=log_title_refresh_batch,
+        )
         updated = 0
         for summary in targeted_summaries:
             paper = summary.paper
@@ -463,6 +500,7 @@ class Pipeline:
             editor_brief = None
             trace_attempt_no = attempt_offset + attempt + 1
             try:
+                self._log_stage_progress(papers, category, "editor", "start", attempt_no=trace_attempt_no)
                 if reviewer_retry_feedback:
                     editor_brief = self.ai_processor.run_editor(
                         papers,
@@ -473,8 +511,17 @@ class Pipeline:
                     editor_brief = self.ai_processor.run_editor(papers, category)
                 editor_records = self.ai_processor.parse_editor_records(editor_brief, papers)
                 self._record_editor_traces(papers, editor_records, attempt_no=trace_attempt_no)
+                self._log_stage_progress(papers, category, "editor", "generated", attempt_no=trace_attempt_no)
                 break
             except StructuredOutputError as exc:
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "editor",
+                    "invalid",
+                    attempt_no=trace_attempt_no,
+                    detail=exc,
+                )
                 self._record_uniform_stage_traces(
                     papers,
                     stage="editor",
@@ -486,12 +533,21 @@ class Pipeline:
                     editor_brief = self.ai_processor.repair_editor_output(exc.raw_output, papers, category)
                     editor_records = self.ai_processor.parse_editor_records(editor_brief, papers)
                     self._record_editor_traces(papers, editor_records, attempt_no=trace_attempt_no)
+                    self._log_stage_progress(papers, category, "editor", "repaired", attempt_no=trace_attempt_no)
                     break
                 except Exception:
                     pass
                 if attempt >= max_retries:
                     raise
-            except Exception:
+            except Exception as exc:
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "editor",
+                    "error",
+                    attempt_no=trace_attempt_no,
+                    detail=exc,
+                )
                 if editor_brief:
                     self._record_uniform_stage_traces(
                         papers,
@@ -514,6 +570,7 @@ class Pipeline:
             writer_output = None
             trace_attempt_no = attempt_offset + attempt + 1
             try:
+                self._log_stage_progress(papers, category, "writer", "start", attempt_no=trace_attempt_no)
                 writer_output = self.ai_processor.run_writer(
                     editor_brief=editor_brief,
                     papers_metadata=papers,
@@ -522,7 +579,16 @@ class Pipeline:
                 )
                 writer_records = self.ai_processor.parse_writer_records(writer_output, papers, category)
                 self._record_writer_traces(papers, writer_records, attempt_no=trace_attempt_no)
+                self._log_stage_progress(papers, category, "writer", "generated", attempt_no=trace_attempt_no)
             except StructuredOutputError as exc:
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "writer",
+                    "invalid",
+                    attempt_no=trace_attempt_no,
+                    detail=exc,
+                )
                 self._record_uniform_stage_traces(
                     papers,
                     stage="writer",
@@ -534,6 +600,7 @@ class Pipeline:
                     writer_output = self.ai_processor.repair_writer_output(exc.raw_output, papers, category)
                     writer_records = self.ai_processor.parse_writer_records(writer_output, papers, category)
                     self._record_writer_traces(papers, writer_records, attempt_no=trace_attempt_no)
+                    self._log_stage_progress(papers, category, "writer", "repaired", attempt_no=trace_attempt_no)
                 except Exception:
                     if attempt >= max_retries:
                         raise
@@ -545,6 +612,14 @@ class Pipeline:
                     )
                     continue
             except Exception as exc:
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "writer",
+                    "error",
+                    attempt_no=trace_attempt_no,
+                    detail=exc,
+                )
                 if writer_output:
                     self._record_uniform_stage_traces(
                         papers,
@@ -564,6 +639,7 @@ class Pipeline:
                 continue
 
             try:
+                self._log_stage_progress(papers, category, "reviewer", "start", attempt_no=trace_attempt_no)
                 review_result = self.ai_processor.run_reviewer(writer_output)
                 rejected_ids = review_result["rejected_ids"] if review_result["status"] == "REJECTED" else []
                 self._record_reviewer_traces(
@@ -588,8 +664,17 @@ class Pipeline:
                 ]
 
                 if review_result["status"] == "PASSED":
+                    self._log_stage_progress(papers, category, "reviewer", "accepted", attempt_no=trace_attempt_no)
                     return parsed_results, [], review_result["raw_output"]
 
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "reviewer",
+                    "rejected",
+                    attempt_no=trace_attempt_no,
+                    detail="ids=" + (",".join(rejected_ids) or "-"),
+                )
                 last_rejected_ids = rejected_ids
                 if not settings.PIPELINE_REVIEWER_STRICT:
                     _safe_progress_log(
@@ -627,6 +712,14 @@ class Pipeline:
                     ]
                 )
             except StructuredOutputError as exc:
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "reviewer",
+                    "invalid",
+                    attempt_no=trace_attempt_no,
+                    detail=exc,
+                )
                 self._record_uniform_stage_traces(
                     papers,
                     stage="reviewer",
@@ -677,8 +770,23 @@ class Pipeline:
                         if record["arxiv_id"] not in set(rejected_ids)
                     ]
                     if review_result["status"] == "PASSED":
+                        self._log_stage_progress(
+                            papers,
+                            category,
+                            "reviewer",
+                            "accepted",
+                            attempt_no=trace_attempt_no,
+                        )
                         return parsed_results, [], review_result["raw_output"]
 
+                    self._log_stage_progress(
+                        papers,
+                        category,
+                        "reviewer",
+                        "rejected",
+                        attempt_no=trace_attempt_no,
+                        detail="ids=" + (",".join(rejected_ids) or "-"),
+                    )
                     last_rejected_ids = rejected_ids
                     if not settings.PIPELINE_REVIEWER_STRICT:
                         _safe_progress_log(
@@ -716,7 +824,15 @@ class Pipeline:
                         ]
                     )
                     continue
-                except Exception:
+                except Exception as repair_exc:
+                    self._log_stage_progress(
+                        papers,
+                        category,
+                        "reviewer",
+                        "error",
+                        attempt_no=trace_attempt_no,
+                        detail=repair_exc,
+                    )
                     if attempt >= max_retries:
                         raise
                     writer_history.append(
@@ -726,6 +842,14 @@ class Pipeline:
                         }
                     )
             except Exception as exc:
+                self._log_stage_progress(
+                    papers,
+                    category,
+                    "reviewer",
+                    "error",
+                    attempt_no=trace_attempt_no,
+                    detail=exc,
+                )
                 if not settings.PIPELINE_REVIEWER_STRICT:
                     _safe_progress_log(
                         (

--- a/tests/backend/unit/test_pipeline_rules.py
+++ b/tests/backend/unit/test_pipeline_rules.py
@@ -6,6 +6,7 @@ import pytest
 from app.core.config import settings
 from app.models.domain import Paper, PaperAITrace, PaperSummary, SystemTaskLog
 from app.services.ai_processor import StructuredOutputError
+import app.services.pipeline as pipeline_module
 from app.services.pipeline import Pipeline
 
 
@@ -696,7 +697,7 @@ def test_refresh_selected_titles_updates_all_issue_fallbacks(db_session):
     db_session.commit()
 
     pipeline = Pipeline(db_session)
-    pipeline.ai_processor.localize_titles = lambda papers, batch_size=None: {
+    pipeline.ai_processor.localize_titles = lambda papers, batch_size=None, progress_callback=None: {
         paper["arxiv_id"]: (
             "面向生产的智能体规划"
             if paper["arxiv_id"] == "2603.00001"
@@ -712,6 +713,63 @@ def test_refresh_selected_titles_updates_all_issue_fallbacks(db_session):
     assert updated == 2
     assert focus_paper.title_zh == "面向生产的智能体规划"
     assert candidate_paper.title_zh == "长周期训练信号"
+
+
+def test_refresh_selected_titles_emits_batch_progress_logs(db_session, monkeypatch):
+    issue_date = Pipeline._resolve_issue_date("2026-03-27")
+    papers = [
+        Paper(
+            arxiv_id=f"2603.1000{index}",
+            title_zh=f"待翻译：Title {index}",
+            title_original=f"Title {index}",
+            authors=[{"name": f"Author {index}", "affiliation": "OpenAI"}],
+            venue="arXiv",
+            abstract="demo",
+            pdf_url=f"https://arxiv.org/pdf/2603.1000{index}.pdf",
+            upvotes=index,
+            arxiv_publish_date=Pipeline._resolve_issue_date("2026-03-24"),
+        )
+        for index in range(1, 4)
+    ]
+    db_session.add_all(papers)
+    db_session.flush()
+    db_session.add_all(
+        [
+            PaperSummary(
+                paper_id=paper.id,
+                issue_date=issue_date,
+                score=50,
+                score_reasons={},
+                category="candidate",
+                candidate_reason="low_score",
+                direction="Agent",
+            )
+            for paper in papers
+        ]
+    )
+    db_session.commit()
+
+    logs = []
+    monkeypatch.setattr(settings, "KIMI_TITLE_BATCH_SIZE", 2)
+    monkeypatch.setattr(pipeline_module, "_safe_progress_log", logs.append)
+
+    pipeline = Pipeline(db_session)
+
+    def fake_localize_titles(payload, batch_size=None, progress_callback=None):
+        if progress_callback is not None:
+            progress_callback(1, 2, 2)
+            progress_callback(2, 2, 1)
+        return {paper["arxiv_id"]: f"中文标题 {paper['arxiv_id']}" for paper in payload}
+
+    pipeline.ai_processor.localize_titles = fake_localize_titles
+
+    updated = pipeline._refresh_selected_titles(issue_date)
+
+    assert updated == 3
+    assert logs == [
+        "[pipeline][title-refresh] issue_date=2026-03-27 batch=1/2 size=2 total=3",
+        "[pipeline][title-refresh] issue_date=2026-03-27 batch=2/2 size=1 total=3",
+    ]
 
 
 def test_run_ai_batch_persists_editor_writer_and_reviewer_traces(db_session):
@@ -788,6 +846,83 @@ def test_run_ai_batch_persists_editor_writer_and_reviewer_traces(db_session):
     assert [trace.stage for trace in traces] == ["editor", "writer", "reviewer"]
     assert traces[2].stage_status == "accepted"
     assert traces[1].content.startswith("## [2503.22001]")
+
+
+def test_run_ai_batch_emits_stage_progress_logs(db_session, monkeypatch):
+    paper = Paper(
+        arxiv_id="2503.22003",
+        title_zh="测试标题三",
+        title_original="Test Title Three",
+        authors=[{"name": "Cara", "affiliation": "OpenAI"}],
+        venue="ICLR 2026",
+        abstract="Test abstract",
+        pdf_url="https://arxiv.org/pdf/2503.22003.pdf",
+        upvotes=10,
+        arxiv_publish_date=Pipeline._resolve_issue_date("2026-03-20"),
+    )
+    db_session.add(paper)
+    db_session.flush()
+
+    summary = PaperSummary(
+        paper_id=paper.id,
+        issue_date=Pipeline._resolve_issue_date("2026-03-23"),
+        score=95,
+        score_reasons={},
+        category="focus",
+        candidate_reason=None,
+        direction="Agent",
+    )
+    db_session.add(summary)
+    db_session.flush()
+
+    logs = []
+    monkeypatch.setattr(pipeline_module, "_safe_progress_log", logs.append)
+
+    pipeline = Pipeline(db_session)
+    pipeline.ai_processor.run_editor = lambda papers, category: "editor-output"
+    pipeline.ai_processor.parse_editor_records = lambda output, papers: [
+        {
+            "arxiv_id": "2503.22003",
+            "writing_angle": "生产落地",
+            "core_problem": "推理链路不稳",
+            "solution": "统一编排",
+            "content": "## 论文: [2503.22003]\n- **写作角度**: 生产落地",
+        }
+    ]
+    pipeline.ai_processor.run_writer = lambda editor_brief, papers_metadata, category, history=None: "writer-output"
+    pipeline.ai_processor.parse_writer_records = lambda writer_output, papers_metadata, category: [
+        {
+            "arxiv_id": "2503.22003",
+            "one_line_summary": "中文总结",
+            "one_line_summary_en": "English summary",
+            "core_highlights": ["亮点一", "亮点二", "亮点三"],
+            "core_highlights_en": ["Point 1", "Point 2", "Point 3"],
+            "application_scenarios": "中文场景",
+            "application_scenarios_en": "English scenario",
+            "content": "## [2503.22003]\n- **一句话总结**: 中文总结",
+        }
+    ]
+    pipeline.ai_processor.run_reviewer = lambda writer_output: {
+        "status": "PASSED",
+        "rejected_ids": [],
+        "raw_output": "- **整体结论**: PASSED\n- **拒绝名单**: []",
+    }
+
+    results, rejected_ids = pipeline._run_ai_batch(
+        [{"arxiv_id": "2503.22003", "_summary": summary}],
+        "focus",
+    )
+
+    assert rejected_ids == []
+    assert results[0]["one_line_summary"] == "中文总结"
+    assert logs == [
+        "[pipeline][focus][2503.22003][editor] start attempt=1",
+        "[pipeline][focus][2503.22003][editor] generated attempt=1",
+        "[pipeline][focus][2503.22003][writer] start attempt=1",
+        "[pipeline][focus][2503.22003][writer] generated attempt=1",
+        "[pipeline][focus][2503.22003][reviewer] start attempt=1",
+        "[pipeline][focus][2503.22003][reviewer] accepted attempt=1",
+    ]
 
 
 def test_run_ai_batch_persists_invalid_attempt_traces(db_session):
@@ -1003,7 +1138,7 @@ def test_run_requeues_full_agent_pipeline_after_reviewer_rejections_until_succes
     reviewer_calls = {"count": 0}
 
     pipeline.ai_processor.localize_title = lambda paper: "评审重排论文"
-    pipeline.ai_processor.localize_titles = lambda papers, batch_size=None: {
+    pipeline.ai_processor.localize_titles = lambda papers, batch_size=None, progress_callback=None: {
         paper["arxiv_id"]: "评审重排论文" for paper in papers
     }
 
@@ -1217,7 +1352,7 @@ def test_run_persists_full_daily_snapshot_for_candidate_pool(db_session):
     }
 
     pipeline.ai_processor.localize_title = lambda paper: f"中文标题 {paper['arxiv_id']}"
-    pipeline.ai_processor.localize_titles = lambda papers, batch_size=None: {
+    pipeline.ai_processor.localize_titles = lambda papers, batch_size=None, progress_callback=None: {
         paper["arxiv_id"]: f"候选中文标题 {paper['arxiv_id']}" for paper in papers
     }
     pipeline._run_ai_batch = lambda papers, category: (


### PR DESCRIPTION
This PR improves pipeline observability without changing scoring, selection, retry limits, or persistence behavior.

The user-facing problem was that a long run could appear to stall on the last Focus or Watching item even when the pipeline was still actively progressing. The existing logs only emitted a single line when a paper started processing, then stayed silent while the paper moved through title localization, Editor, Writer, Reviewer, repair paths, and any reviewer-triggered requeues. The final title backfill step also ran as a silent bulk operation, so the gap between the last paper log and the final SUCCESS payload was hard to interpret during production debugging.

Root cause: the pipeline had paper-level progress logs but no stage-level visibility, and `_refresh_selected_titles()` performed batched title localization without any per-batch progress output.

This change adds two forms of logging only:

1. Per-paper stage logs for `editor`, `writer`, and `reviewer`, including start and terminal outcomes such as generated, accepted, rejected, invalid, repaired, and error.
2. Batch progress logs for `_refresh_selected_titles()` so long candidate-title refresh runs report batch index, batch size, and total count.

The implementation keeps the existing pipeline behavior intact. The only interface change is that `AIProcessor.localize_titles()` now accepts an optional `progress_callback`; when omitted, execution is unchanged. The pipeline is the only in-repo caller that uses the callback, and it uses it purely for logging.

Validation:
- `cd backend && ./venv/bin/pytest ../tests/backend/unit/test_pipeline_rules.py`
- `cd backend && ./venv/bin/pytest ../tests/backend/unit/test_ai_processor.py`

Both test suites passed locally.
